### PR TITLE
Fixed a bug with the detach_irq function

### DIFF
--- a/IoTPy/pyuper/gpio.py
+++ b/IoTPy/pyuper/gpio.py
@@ -140,6 +140,8 @@ class UPER1_GPIO(GPIO):
             return False
 
         self.board.interrupts[irq_id] = None
+        del self.board.callbackdict[self.logical_pin]
+        self.board.uper_io(0, self.board.encode_sfp(7, [irq_id]))
         return True
 
     def get_irq_count(self):


### PR DESCRIPTION
Completly detach the interrupt in firmware, and clear the entry in the callbackdict
